### PR TITLE
feat(deploy): added kubernetes deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ seeders
 
 # Logs
 logs
+
+kubernetes/secrets.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,19 @@ services:
       dockerfile: Dockerfile
     container_name: workshift-svc
     environment:
-      - MONGODB_URL=${MONGOURL}
       - PORT=3011
+      - MONGOADMIN=${MONGOADMIN}
+      - MONGOPASS=${MONGOPASS}
+      - MONGOURL=${MONGOURL}
+      - NODE_ENV=production
+      - RABBIT_USERNAME=${RABBIT_USERNAME}
+      - RABBIT_PASSWORD=${RABBIT_PASSWORD}
+      - RABBIT_HOST=${RABBIT_HOST}
+      - RABBIT_PORT=${RABBIT_PORT}
+      - RABBIT_VHOST=${RABBIT_VHOST}
+      - API_PREFIX=/api/v1
+      - JWT_SECRET=${JWT_SECRET}
+      - KAFKA_HOST=${KAFKA_HOST}
     depends_on:
       - mongodb
     networks:

--- a/kubernetes/mongo-data-workshift-persistentvolumeclaim.yaml
+++ b/kubernetes/mongo-data-workshift-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: mongo-data-workshift
+  name: mongo-data-workshift
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (HEAD)
+      labels:
+        io.kompose.service: mongodb
+    spec:
+      containers:
+        - env:
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: appointment-secrets
+                  key: MONGOPASS
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: appointment-secrets
+                  key: MONGOADMIN
+          image: mongo:latest
+          name: mongodb-workshift
+          ports:
+            - containerPort: 27017
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongo-data-workshift
+      restartPolicy: Always
+      volumes:
+        - name: mongo-data-workshift
+          persistentVolumeClaim:
+            claimName: mongo-data-workshift

--- a/kubernetes/mongodb-service.yaml
+++ b/kubernetes/mongodb-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: mongodb

--- a/kubernetes/workshift-svc-deployment.yaml
+++ b/kubernetes/workshift-svc-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: workshift
+  name: workshift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: workshift
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (HEAD)
+      labels:
+        io.kompose.service: workshift
+    spec:
+      containers:
+        - env:
+            - name: API_PREFIX
+              value: /api/v1
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: JWT_SECRET
+            - name: MONGOADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: MONGOADMIN
+            - name: MONGOPASS
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: MONGOPASS
+            - name: MONGOURL
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: MONGOURL
+            - name: NODE_ENV
+              value: development
+            - name: PORT
+              value: "3011"
+            - name: RABBIT_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: RABBIT_HOST
+            - name: RABBIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: RABBIT_PASSWORD
+            - name: RABBIT_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: RABBIT_PORT
+            - name: RABBIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: RABBIT_USERNAME
+            - name: KAFKA_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: workshift-secrets
+                  key: KAFKA_HOST
+          image: ghcr.io/fis2425/workshift:latest
+          name: workshift
+          ports:
+            - containerPort: 3011
+              protocol: TCP
+      restartPolicy: Always

--- a/kubernetes/workshift-svc-service.yaml
+++ b/kubernetes/workshift-svc-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: workshift
+  name: workshift-svc
+spec:
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 3011
+      targetPort: 3011
+      nodePort: 30011
+  selector:
+    io.kompose.service: workshift

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node --env-file=.env ./src/config/index.js",
+    "start": "node ./src/config/index.js",
     "lint": "eslint . --max-warnings=0 --cache --cache-location node_modules/.cache/eslint",
     "lint-fix": "eslint . --fix --max-warnings=0 --cache --cache-location node_modules/.cache/eslint",
     "dev": "node --watch --env-file=.env ./src/config/index.js",


### PR DESCRIPTION
This pull request includes significant changes to the deployment and configuration of the `workshift` service, including updates to Docker, Kubernetes configurations, and environment variables.

### Docker and Environment Configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L23-R35): Added multiple environment variables for MongoDB, RabbitMQ, Kafka, and JWT configuration.

### Kubernetes Configuration:

* [`kubernetes/mongo-data-workshift-persistentvolumeclaim.yaml`](diffhunk://#diff-c6212fb9c680b02d1e3e799cd2314396a5361dafeb8a9d4b161dcfcff0aa02f5R1-R12): Added a new PersistentVolumeClaim for MongoDB data storage.
* [`kubernetes/mongodb-deployment.yaml`](diffhunk://#diff-37303c2921f0256f198ee864e1b2ca069f8e3485b6a6513a627c5c3e870f0d00R1-R49): Added a new Deployment configuration for MongoDB, including environment variables for MongoDB credentials from secrets.
* [`kubernetes/mongodb-service.yaml`](diffhunk://#diff-4094af2a5f5058f456d8d49437f645bf8f1abef40bcb804acc4425cd742a9600R1-R18): Added a new Service configuration for MongoDB with ClusterIP type.
* [`kubernetes/workshift-svc-deployment.yaml`](diffhunk://#diff-9db3ae03f9e0fb73af7c2fece42e0e05c8ddb8478d1a490c15487f3ca9139fa8R1-R81): Added a new Deployment configuration for the `workshift` service, including environment variables for various services and secrets.
* [`kubernetes/workshift-svc-service.yaml`](diffhunk://#diff-929c4efa9e81a60ebef434e1c04bda88bfd11ecb87e867e2f45fc7fb27439258R1-R18): Added a new Service configuration for the `workshift` service with LoadBalancer type.

### Package Configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14): Updated the `start` script to remove the `--env-file` option.